### PR TITLE
Add ExtraFields.

### DIFF
--- a/src/CloudEventData/CloudEventData.csproj
+++ b/src/CloudEventData/CloudEventData.csproj
@@ -14,6 +14,9 @@
     <PackageTags>CloudEvent</PackageTags>
     <PackageReleaseNotes>start</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +24,10 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/CloudEventData/CloudEventRequest.cs
+++ b/src/CloudEventData/CloudEventRequest.cs
@@ -1,41 +1,88 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace CloudEventData
+namespace CloudEventData;
+
+public class CloudEventRequest
 {
-    public class CloudEventRequest
-    {
+    #region Required fields
+    
+    /// <summary>
+    /// Unique identifier for the event within the scope of the producer.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
 
-        /// <summary>
-        /// This attribute contains a value describing the type of event related to the originating occurrence. Often this attribute is used for routing, observability, policy enforcement, etc. The format of this is producer defined and might include information such as the version of the type - see Versioning of Attributes in the Primer for more information.
-        /// </summary>
-        public string Type { get; set; }
-        //public string SpecVersion => "1.0";
-        /// <summary>
-        /// MUST be a non-empty URI-reference, an absolute URI is RECOMMENDED
-        /// Examples:
-        /// https://github.com/cloudevents
-        /// sensors/tn-1234567/alerts
-        /// </summary>
-        public Uri Source { get; set; }
-        /// <summary>
-        /// MUST be unique within the scope of the producer
-        /// </summary>
-        public string Id { get; set; }
-        /// <summary>
-        /// Timestamp of when the occurrence happened
-        /// </summary>
-        public DateTime Time { get; set; }
-        /// <summary>
-        /// Example when sending Data as Json: 'application/json'
-        /// </summary>
-        public string DataContentType { get; set; }
-        /// <summary>
-        /// Identifies the schema that data adheres to. Incompatible changes to the schema SHOULD be reflected by a different URI. See Versioning of Attributes in the Primer for more information
-        /// </summary>
-        public Uri DataSchema { get; set; }
-        /// <summary>
-        /// The event payload. This specification does not place any restriction on the type of this information. It is encoded into a media format which is specified by the datacontenttype attribute (e.g. application/json), and adheres to the dataschema format when those respective attributes are present
-        /// </summary>
-        public dynamic Data { get; set; }
-    }
+    /// <summary>
+    /// The source of the event. Must be a non-empty URI-reference.
+    /// An absolute URI is recommended.
+    /// Examples:
+    /// https://github.com/cloudevents
+    /// sensors/tn-1234567/alerts
+    /// </summary>
+    [JsonPropertyName("source")]
+    public Uri Source { get; set; }
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// This enables the interpretation of the context.
+    /// Compliant event producers MUST use a value of 1.0 when referring to this version of the specification.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public string SpecVersion { get; set; }
+
+    /// <summary>
+    /// Describes the type of event related to the originating occurrence.
+    /// Often used for routing, observability, policy enforcement, etc.
+    /// The format is producer-defined and might include version information.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    #endregion
+    
+    #region Optional fields
+    
+    /// <summary>
+    /// The content type of the data being sent. Example: 'application/json'.
+    /// </summary>
+    [JsonPropertyName("datacontenttype")]
+    public string? DataContentType { get; set; }
+
+    /// <summary>
+    /// Identifies the schema that the data adheres to.
+    /// Incompatible changes to the schema should be reflected by a different URI.
+    /// </summary>
+    [JsonPropertyName("dataschema")]
+    public Uri? DataSchema { get; set; }
+
+    /// <summary>
+    /// Describes the subject of the event in the context of the event producer.
+    /// </summary>
+    [JsonPropertyName("subject")]
+    public string? Subject { get; set; }
+
+    /// <summary>
+    /// Timestamp of when the occurrence happened.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public DateTime? Time { get; set; }
+
+    /// <summary>
+    /// The event payload. This specification does not restrict the type of this information.
+    /// It is encoded into a media format specified by the DataContentType attribute (e.g., application/json),
+    /// and adheres to the DataSchema format when those respective attributes are present.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public dynamic? Data { get; set; }
+    
+    #endregion
+
+    /// <summary>
+    /// A dictionary to hold any extra fields that are not mapped to the above properties.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement> ExtraFields { get; set; }
 }


### PR DESCRIPTION
The CloudEvent spec allows for extension attributes: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#extension-context-attributes

> A CloudEvent MAY include any number of additional context attributes with distinct names, known as "extension attributes". Extension attributes MUST follow the same [naming convention](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#attribute-naming-convention) and use the same [type system](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system) as standard attributes.

Currently CloudEventRequest does not provide for a way to capture these fields, this PR does through the use of `JsonExtensionData` from `System.Text.Json`.

The spec also specifies that keys should be lowercase: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#attribute-naming-convention

> CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set. Attribute names SHOULD be descriptive and terse and SHOULD NOT exceed 20 characters in length.

This PR corrects this behaviour, whilst not excluding that for deserialisation an insensitive resolver could be used to handle non-conforming CloudEvents.